### PR TITLE
Detalhamento da instalação e criação dos ingress

### DIFF
--- a/2-istio-minikube.yaml
+++ b/2-istio-minikube.yaml
@@ -16312,10 +16312,6 @@ spec:
 
   ports:
     -
-      name: status-port
-      port: 15020
-      targetPort: 15020
-    -
       name: http2
       port: 80
       targetPort: 80
@@ -16323,30 +16319,18 @@ spec:
     -
       name: https
       port: 443
-    -
-      name: kiali
-      port: 15029
-      targetPort: 15029
-    -
-      name: prometheus
-      port: 15030
-      targetPort: 15030
-    -
-      name: grafana
-      port: 15031
-      targetPort: 15031
-    -
-      name: tracing
-      port: 15032
-      targetPort: 15032
+      targetPort: 443
+      nodePort: 31443
     -
       name: tcp
       port: 31400
       targetPort: 31400
+      nodePort: 32400
     -
       name: tls
       port: 15443
       targetPort: 15443
+      nodePort: 32443
 ---
 
 

--- a/4-istio-ingress.yaml
+++ b/4-istio-ingress.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: grafana
+  namespace: istio-system
+spec:
+  rules:
+    - host: grafana.{{CLUSTER_IP}}.nip.io
+      http:
+        paths:
+          - backend:
+             serviceName: grafana
+             servicePort: 3000
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  rules:
+    - host: kiali.{{CLUSTER_IP}}.nip.io
+      http:
+        paths:
+          - backend:
+             serviceName: kiali
+             servicePort: 20001
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: jaeger
+  namespace: istio-system
+spec:
+  rules:
+    - host: jaeger.{{CLUSTER_IP}}.nip.io
+      http:
+        paths:
+          - backend:
+             serviceName: jaeger-query
+             servicePort: 16686
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: apps-ingress
+  namespace: istio-system
+spec:
+  rules:
+    - host: "*.apps.{{CLUSTER_IP}}.nip.io"
+      http:
+        paths:
+          - backend:
+             serviceName: istio-ingressgateway
+             servicePort: 80

--- a/README.md
+++ b/README.md
@@ -1,7 +1,54 @@
 # istio-environment
-Configuração ambiente istio
 
-Após rodar kubectl apply -f 'arquivo' , deve adicionar label ao namespace desejado conforme abaixo : 
+Arquivos para a instalação do Istio no Minikube
 
-kubectl label namespace default istio-injection=enabled
+## Como instalar
 
+### Minikube
+
+Criar um cluster com o minikube de forma padrão:
+
+_Obs_: Caso você utilize alguma ferramenta de virtualização (ex.: virtualbox), passar via ``--vm-driver=`` como ultimo argumento do codigo abaixo.
+
+````shell
+minikube start --memory=3Gb --cpu=3
+````
+
+Habilitar os addons ingress e dashboard
+
+````shell
+minikube addons enable dashboard
+
+minikube addons enable ingress
+````
+
+Criar um host para o dashboard
+````shell
+cat dashboard-ingress.yaml | sed s/{{CLUSTER_IP}}/$(minikube ip)/g dashboard-ingress.yaml | kubectl apply -f -
+````
+
+Agora você pode acessar o dashboard do seu cluster kubernetes via: ``http://dashboard.<IP DO SEU CLUSTER>.nip.io``
+
+### Istio
+
+Aplicar os recursos conforme o numero de cada um:
+
+````shell
+kubectl apply -f 1-istio-init.yaml
+
+kubectl apply -f 2-istio-minikube.yaml
+
+kubectl apply -f 3-istio-secret.yaml
+
+cat 4-istio-ingress.yaml | sed s/{{CLUSTER_IP}}/$(minikube ip)/g 4-istio-ingress.yaml | kubectl apply -f -
+
+````
+
+## Como utilizar
+
+Após aplicar os recursos acima, deve-se adicionar a label de injection ao namespace desejado conforme abaixo:
+
+````shell
+export NAMESPACE=seu-namespace
+kubectl label namespace $NAMESPACE istio-injection=enabled
+````

--- a/dashboard-ingress.yaml
+++ b/dashboard-ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+spec:
+  rules:
+    - host: dashboard.{{CLUSTER_IP}}.nip.io
+      http:
+        paths:
+          - backend:
+             serviceName: kubernetes-dashboard
+             servicePort: 9090


### PR DESCRIPTION
Este PR contem as seguintes mudanças:

**Minikube**
- Exposição do dashboard via ingress
- Documentação da instalação de addons no cluster do minikube.

**Istio**
- Remoção dos endpoints sem uso no service istio-ingressgateway
       - Os endpoints de kiali, tracing, prometheus e grafana não estavam funcionando, para simplificar eles foram removidos
- Criação dos ingress para kiali, jaeger e grafana
       - Estes ingress possibilitam o acesso aos serviços citados via DNS, sem a necessidade de exposição de portas
- Criação de um ingress coringa para as aplicações
       - Possibilita a criação dinamica dos hosts para as aplicações, garantindo que a entrada se dê via ingressgateway do istio (será adicionado ao readme no futuro como utiliza-lo).

